### PR TITLE
jackd1 is actually needed, otherwise the snap is unable to list avail…

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -82,7 +82,7 @@ parts:
       cp -a Builds/LinuxMakefile/build/SonoBus $SNAPCRAFT_PART_INSTALL/bin/
       cp -a Builds/LinuxMakefile/build/SonoBus.vst3 $SNAPCRAFT_PART_INSTALL/lib/vst3/
     stage-packages:
-      - libjack0
+      - jackd1
       - libopus0
       - libasound2
       - libx11-6


### PR DESCRIPTION
`jackd1` is actually needed in the `stage-packages` of the `sonobus` part , otherwise the snap is unable to list available inputs and outputs.
![sonobus_snap](https://nextcloud.frenchguy.ch/index.php/s/Ne67s5cMaAjaGKT/preview)