### PR TITLE
snapcraft.yaml: Drop audio-playback and audio-record plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -101,8 +101,6 @@ apps:
       - bin/desktop-launch
       - snap/command-chain/alsa-launch
     plugs:
-      - audio-playback
-      - audio-record
       - alsa
       - home
       - network


### PR DESCRIPTION
SonoBus does not use PulseAudio, therefore the audio-playback and audio-record-plugs (which are Pulse specific) are not required.
